### PR TITLE
Gpu to compute

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,21 +1,6 @@
-use std::{sync::Arc, thread};
+use std::thread;
 
 use num::Complex;
-use winit::window::Window;
-
-pub struct Cpu {
-    pub context: softbuffer::Context<Arc<Window>>,
-    pub surface: softbuffer::Surface<Arc<Window>, Arc<Window>>,
-}
-
-impl Cpu {
-    pub fn new(window: Arc<Window>) -> Self {
-        let context = softbuffer::Context::new(Arc::clone(&window)).unwrap();
-        let surface = softbuffer::Surface::new(&context, window).unwrap();
-
-        Cpu { context, surface }
-    }
-}
 
 fn escape_time(c: Complex<f32>, limit: usize) -> Option<usize> {
     assert!(limit <= 256, "Limit must not exceed 256.");

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,7 +1,6 @@
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 use wgpu::{BindGroupEntry, BufferBinding, BufferUsages, Device, Queue};
-use winit::window::Window;
 
 pub struct Wgpu {
     pub device: Device,
@@ -9,7 +8,7 @@ pub struct Wgpu {
 }
 
 impl Wgpu {
-    pub async fn new(window: Arc<Window>) -> Self {
+    pub async fn new() -> Self {
         let instance = wgpu::Instance::default();
         // Request an adapter that can support our surface
         let adapter = instance

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,0 +1,244 @@
+use std::{borrow::Cow, sync::Arc};
+
+use wgpu::{BindGroupEntry, BufferBinding, BufferUsages, Device, Queue};
+use winit::window::Window;
+
+pub struct Wgpu {
+    pub device: Device,
+    pub queue: Queue,
+}
+
+impl Wgpu {
+    pub async fn new(window: Arc<Window>) -> Self {
+        let instance = wgpu::Instance::default();
+        // Request an adapter that can support our surface
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .expect("Failed to find an appropriate adapter");
+
+        // Create logical device and command queue
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: None,
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: wgpu::Trace::Off,
+            })
+            .await
+            .expect("Failed to create device");
+        println!("Prepared device: {:?}", device);
+
+        Wgpu { device, queue }
+    }
+
+    pub fn render(
+        &mut self,
+        buffer: &mut [u32],
+        upper_left: (f32, f32),
+        view_resolution: (f32, f32),
+        window_resolution: &winit::dpi::PhysicalSize<u32>,
+    ) {
+        // PREPARE COMPUTE
+        // allocate local texture representation
+        let mut texture_data =
+            vec![0u8; (window_resolution.width * window_resolution.height * 4) as usize];
+        // Load the shaders
+        let shader = self
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("shader"),
+                source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
+            });
+
+        // Storage texture for calculation output
+        let storage_texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("mandelbrot result texture"),
+            size: wgpu::Extent3d {
+                width: window_resolution.width,
+                height: window_resolution.height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        // TODO why default?
+        let storage_texture_view =
+            storage_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_staging_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("output staging buffer"),
+            size: size_of_val(&texture_data[..]) as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+
+        // Uniform buffer
+        let uniform_buffer = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("settings_uniform"),
+            size: 6 * size_of::<f32>() as u64,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bind_group_layout =
+            self.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("Bind group layout"),
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::StorageTexture {
+                                access: wgpu::StorageTextureAccess::WriteOnly,
+                                format: wgpu::TextureFormat::Rgba8Unorm,
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                            },
+                            count: None,
+                        },
+                    ],
+                });
+
+        // Create bind group
+        let bind_group = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("bind group"),
+            layout: &bind_group_layout,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(BufferBinding {
+                        buffer: &uniform_buffer,
+                        offset: 0,
+                        size: None, // use whole buffer
+                    }),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&storage_texture_view),
+                },
+            ],
+        });
+
+        // Pipeline
+        let pipeline_layout = self
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("pipeline_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+        let compute_pipeline =
+            self.device
+                .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                    label: Some("mandelbrot compute pipeline"),
+                    layout: Some(&pipeline_layout),
+                    module: &shader,
+                    entry_point: Some("main"),
+                    compilation_options: Default::default(),
+                    cache: None,
+                });
+
+        self.queue.write_buffer(
+            &uniform_buffer,
+            0,
+            &[
+                upper_left.0,
+                upper_left.1,
+                view_resolution.0,
+                view_resolution.1,
+                window_resolution.width as f32,
+                window_resolution.height as f32,
+            ]
+            .iter()
+            .flat_map(|entry| entry.to_ne_bytes())
+            .collect::<Vec<u8>>(),
+        );
+
+        let mut command_encoder =
+            self.device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("compute command encoder"),
+                });
+        {
+            // run computation command
+            let mut compute_pass =
+                command_encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("compute pass"),
+                    timestamp_writes: None,
+                });
+            compute_pass.set_bind_group(0, &bind_group, &[]);
+            compute_pass.set_pipeline(&compute_pipeline);
+            compute_pass.dispatch_workgroups(window_resolution.width, window_resolution.height, 1);
+        }
+
+        // download texture command
+        command_encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfoBase {
+                texture: &storage_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfoBase {
+                buffer: &output_staging_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(window_resolution.width * 4),
+                    rows_per_image: Some(window_resolution.height),
+                },
+            },
+            wgpu::Extent3d {
+                width: window_resolution.width,
+                height: window_resolution.height,
+                depth_or_array_layers: 1,
+            },
+        );
+        self.queue.submit(Some(command_encoder.finish()));
+
+        let buffer_slice = output_staging_buffer.slice(..);
+        // TODO do you need to synchronize on the callback result or is it enough that your poll
+        // has returned? for the time being I think it should be enough, but more investigation is
+        // warranted
+        buffer_slice.map_async(wgpu::MapMode::Read, move |_| {});
+        self.device.poll(wgpu::PollType::Wait).unwrap();
+        {
+            let view = buffer_slice.get_mapped_range();
+            texture_data.copy_from_slice(&view[..]);
+        }
+        output_staging_buffer.unmap();
+
+        // this is rather nasty
+        // softbuffer expects the value as ARGB while
+        // the texture is produced as RGBA
+        // TODO maybe we can do better?
+        for row in 0..window_resolution.height {
+            for column in 0..window_resolution.width {
+                let texture_column_width = window_resolution.width * 4;
+                let texture_index = ((row * texture_column_width) + column * 4) as usize;
+                let shifted = (texture_data[texture_index] as u32) << 16
+                    | (texture_data[texture_index + 1] as u32) << 8
+                    | (texture_data[texture_index + 2] as u32);
+                let pixel_index = (row * window_resolution.width + column) as usize;
+                buffer[pixel_index] = shifted;
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-use std::{borrow::Cow, num::NonZeroU32, sync::Arc};
+use std::{num::NonZeroU32, sync::Arc};
 
 use num::Complex;
-use wgpu::{Adapter, BindGroupEntry, BufferBinding, BufferUsages, Device, Queue};
 use winit::{
     application::ApplicationHandler,
     event::{DeviceEvent, ElementState, WindowEvent},
@@ -11,7 +10,10 @@ use winit::{
 };
 
 mod cpu;
+mod gpu;
+
 use cpu::Cpu;
+use gpu::Wgpu;
 
 #[derive(Default)]
 struct App {
@@ -108,137 +110,10 @@ impl ApplicationHandler for App {
                 // Draw.
                 if let Some(app) = self.app.as_mut() {
                     if app.render_with_gpu {
+                        let mut buffer = app.cpu.surface.buffer_mut().unwrap();
+
                         // Adjusted physical resolution for the given dpi setting on a given screen.
                         let window_resolution = app.window.inner_size();
-
-                        // PREPARE COMPUTE
-                        // allocate local texture representation
-                        let mut texture_data = vec![
-                            0u8;
-                            (window_resolution.width * window_resolution.height * 4)
-                                as usize
-                        ];
-                        // Load the shaders
-                        let shader =
-                            app.gpu
-                                .device
-                                .create_shader_module(wgpu::ShaderModuleDescriptor {
-                                    label: Some("shader"),
-                                    source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!(
-                                        "shader.wgsl"
-                                    ))),
-                                });
-
-                        // Storage texture for calculation output
-                        let storage_texture =
-                            app.gpu.device.create_texture(&wgpu::TextureDescriptor {
-                                label: Some("mandelbrot result texture"),
-                                size: wgpu::Extent3d {
-                                    width: window_resolution.width,
-                                    height: window_resolution.height,
-                                    depth_or_array_layers: 1,
-                                },
-                                mip_level_count: 1,
-                                sample_count: 1,
-                                dimension: wgpu::TextureDimension::D2,
-                                format: wgpu::TextureFormat::Rgba8Unorm,
-                                usage: wgpu::TextureUsages::STORAGE_BINDING
-                                    | wgpu::TextureUsages::COPY_SRC,
-                                view_formats: &[],
-                            });
-                        // TODO why default?
-                        let storage_texture_view =
-                            storage_texture.create_view(&wgpu::TextureViewDescriptor::default());
-                        let output_staging_buffer =
-                            app.gpu.device.create_buffer(&wgpu::BufferDescriptor {
-                                label: Some("output staging buffer"),
-                                size: size_of_val(&texture_data[..]) as u64,
-                                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-                                mapped_at_creation: false,
-                            });
-
-                        // Uniform buffer
-                        let uniform_buffer =
-                            app.gpu.device.create_buffer(&wgpu::BufferDescriptor {
-                                label: Some("settings_uniform"),
-                                size: 6 * size_of::<f32>() as u64,
-                                usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
-                                mapped_at_creation: false,
-                            });
-
-                        let bind_group_layout = app.gpu.device.create_bind_group_layout(
-                            &wgpu::BindGroupLayoutDescriptor {
-                                label: Some("Bind group layout"),
-                                entries: &[
-                                    wgpu::BindGroupLayoutEntry {
-                                        binding: 0,
-                                        visibility: wgpu::ShaderStages::COMPUTE,
-                                        ty: wgpu::BindingType::Buffer {
-                                            ty: wgpu::BufferBindingType::Uniform,
-                                            has_dynamic_offset: false,
-                                            min_binding_size: None,
-                                        },
-                                        count: None,
-                                    },
-                                    wgpu::BindGroupLayoutEntry {
-                                        binding: 1,
-                                        visibility: wgpu::ShaderStages::COMPUTE,
-                                        ty: wgpu::BindingType::StorageTexture {
-                                            access: wgpu::StorageTextureAccess::WriteOnly,
-                                            format: wgpu::TextureFormat::Rgba8Unorm,
-                                            view_dimension: wgpu::TextureViewDimension::D2,
-                                        },
-                                        count: None,
-                                    },
-                                ],
-                            },
-                        );
-
-                        // Create bind group
-                        let bind_group =
-                            app.gpu
-                                .device
-                                .create_bind_group(&wgpu::BindGroupDescriptor {
-                                    label: Some("bind group"),
-                                    layout: &bind_group_layout,
-                                    entries: &[
-                                        BindGroupEntry {
-                                            binding: 0,
-                                            resource: wgpu::BindingResource::Buffer(
-                                                BufferBinding {
-                                                    buffer: &uniform_buffer,
-                                                    offset: 0,
-                                                    size: None, // use whole buffer
-                                                },
-                                            ),
-                                        },
-                                        BindGroupEntry {
-                                            binding: 1,
-                                            resource: wgpu::BindingResource::TextureView(
-                                                &storage_texture_view,
-                                            ),
-                                        },
-                                    ],
-                                });
-
-                        // Pipeline
-                        let pipeline_layout = app.gpu.device.create_pipeline_layout(
-                            &wgpu::PipelineLayoutDescriptor {
-                                label: Some("pipeline_layout"),
-                                bind_group_layouts: &[&bind_group_layout],
-                                push_constant_ranges: &[],
-                            },
-                        );
-                        let compute_pipeline = app.gpu.device.create_compute_pipeline(
-                            &wgpu::ComputePipelineDescriptor {
-                                label: Some("mandelbrot compute pipeline"),
-                                layout: Some(&pipeline_layout),
-                                module: &shader,
-                                entry_point: Some("main"),
-                                compilation_options: Default::default(),
-                                cache: None,
-                            },
-                        );
 
                         let (upper_left, view_resolution) = center_to_start_conditions(
                             app.center_point,
@@ -246,96 +121,12 @@ impl ApplicationHandler for App {
                             (window_resolution.width, window_resolution.height),
                         );
 
-                        app.gpu.queue.write_buffer(
-                            &uniform_buffer,
-                            0,
-                            &[
-                                upper_left.0,
-                                upper_left.1,
-                                view_resolution.0,
-                                view_resolution.1,
-                                window_resolution.width as f32,
-                                window_resolution.height as f32,
-                            ]
-                            .iter()
-                            .flat_map(|entry| entry.to_ne_bytes())
-                            .collect::<Vec<u8>>(),
+                        app.gpu.render(
+                            &mut buffer,
+                            upper_left,
+                            view_resolution,
+                            &window_resolution,
                         );
-
-                        let mut command_encoder = app.gpu.device.create_command_encoder(
-                            &wgpu::CommandEncoderDescriptor {
-                                label: Some("compute command encoder"),
-                            },
-                        );
-                        {
-                            // run computation command
-                            let mut compute_pass =
-                                command_encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                                    label: Some("compute pass"),
-                                    timestamp_writes: None,
-                                });
-                            compute_pass.set_bind_group(0, &bind_group, &[]);
-                            compute_pass.set_pipeline(&compute_pipeline);
-                            compute_pass.dispatch_workgroups(
-                                window_resolution.width,
-                                window_resolution.height,
-                                1,
-                            );
-                        }
-
-                        // download texture command
-                        command_encoder.copy_texture_to_buffer(
-                            wgpu::TexelCopyTextureInfoBase {
-                                texture: &storage_texture,
-                                mip_level: 0,
-                                origin: wgpu::Origin3d::ZERO,
-                                aspect: wgpu::TextureAspect::All,
-                            },
-                            wgpu::TexelCopyBufferInfoBase {
-                                buffer: &output_staging_buffer,
-                                layout: wgpu::TexelCopyBufferLayout {
-                                    offset: 0,
-                                    bytes_per_row: Some(window_resolution.width * 4),
-                                    rows_per_image: Some(window_resolution.height),
-                                },
-                            },
-                            wgpu::Extent3d {
-                                width: window_resolution.width,
-                                height: window_resolution.height,
-                                depth_or_array_layers: 1,
-                            },
-                        );
-                        app.gpu.queue.submit(Some(command_encoder.finish()));
-
-                        let buffer_slice = output_staging_buffer.slice(..);
-                        // TODO do you need to synchronize on the callback result or is it enough that your poll
-                        // has returned? for the time being I think it should be enough, but more investigation is
-                        // warranted
-                        buffer_slice.map_async(wgpu::MapMode::Read, move |_| {});
-                        app.gpu.device.poll(wgpu::PollType::Wait).unwrap();
-                        {
-                            let view = buffer_slice.get_mapped_range();
-                            texture_data.copy_from_slice(&view[..]);
-                        }
-                        output_staging_buffer.unmap();
-
-                        let mut buffer = app.cpu.surface.buffer_mut().unwrap();
-                        // this is rather nasty
-                        // softbuffer expects the value as ARGB while
-                        // the texture is produced as RGBA
-                        // TODO maybe we can do better?
-                        for row in 0..window_resolution.height {
-                            for column in 0..window_resolution.width {
-                                let texture_column_width = window_resolution.width * 4;
-                                let texture_index =
-                                    ((row * texture_column_width) + column * 4) as usize;
-                                let shifted = (texture_data[texture_index] as u32) << 16
-                                    | (texture_data[texture_index + 1] as u32) << 8
-                                    | (texture_data[texture_index + 2] as u32);
-                                let pixel_index = (row * window_resolution.width + column) as usize;
-                                buffer[pixel_index] = shifted;
-                            }
-                        }
 
                         buffer.present().unwrap();
                     } else {
@@ -527,46 +318,6 @@ impl ApplicationHandler for App {
                 }
             }
             _ => {}
-        }
-    }
-}
-
-struct Wgpu {
-    pub adapter: Adapter,
-    pub device: Device,
-    pub queue: Queue,
-}
-
-impl Wgpu {
-    pub async fn new(window: Arc<Window>) -> Self {
-        let instance = wgpu::Instance::default();
-        // Request an adapter that can support our surface
-        let adapter = instance
-            .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::default(),
-                force_fallback_adapter: false,
-                compatible_surface: None,
-            })
-            .await
-            .expect("Failed to find an appropriate adapter");
-
-        // Create logical device and command queue
-        let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor {
-                label: None,
-                required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::downlevel_defaults(),
-                memory_hints: wgpu::MemoryHints::MemoryUsage,
-                trace: wgpu::Trace::Off,
-            })
-            .await
-            .expect("Failed to create device");
-        println!("Prepared device: {:?}", device);
-
-        Wgpu {
-            adapter,
-            device,
-            queue,
         }
     }
 }

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -1,26 +1,4 @@
 
-// We can do this to have the four vertices or make a buffer, fill it etc..
-// This is simpler.
-const vertices = array<vec4f, 4>(vec4f(-1.0, 1.0, 0.0, 1.0), vec4f(-1.0, -1.0, 0.0, 1.0), vec4f(1.0, 1.0, 0.0, 1.0), vec4f(1.0, -1.0, 0.0, 1.0));
-
-@vertex
-fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> @builtin(position) vec4f {
-    var position: vec4f;
-    // This is a weird trick, necessary as Naga doesn't allow indexing of arrays
-    // with none constant values.
-    if in_vertex_index == 0 {
-        position = vertices[0];
-    } else if in_vertex_index == 1 {
-        position = vertices[1];
-    } else if in_vertex_index == 2 {
-        position = vertices[2];
-    } else {
-        position = vertices[3];
-    }
-
-    return position;
-}
-
 struct Settings {
     upper_left: vec2f,
     view_width: f32,
@@ -28,20 +6,29 @@ struct Settings {
     window: vec2f,
 };
 
-@group(0) @binding(0) var<uniform> settings: Settings;
+@group(0)
+@binding(0)
+var<uniform> settings: Settings;
 
-@fragment
-fn fs_main(@builtin(position) position: vec4f) -> @location(0) vec4<f32> {
+@group(0)
+@binding(1)
+var texture: texture_storage_2d<rgba8unorm, write>;
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    // TODO what is workgroup_size 1, invocation id etc???
     // The position scaling codes might look a bit confusing.
     // What we are doing is taking a pixel position and then transforming it into the mandelbrot space.
-    // This would be written down as (position.x / settings.window.x) * settings.view_width, which is equivalent
-    // to position.x * settings.view_width / settings.window.x. 
-    let point = vec2f(settings.upper_left.x + (position.x * settings.view_width / settings.window.x),
-        settings.upper_left.y - (position.y * settings.view_height / settings.window.y));
+    // This would be written down as (id.x / settings.window.x) * settings.view_width, which is equivalent
+    // to id.x * settings.view_width / settings.window.x. 
+    let point = vec2f(settings.upper_left.x + (f32(id.x) * settings.view_width / settings.window.x),
+        settings.upper_left.y - (f32(id.y) * settings.view_height / settings.window.y));
 
     let escapes_in = escape_time(point, 256u);
     let intensity: f32 = f32(escapes_in) / 255.0;
-    return vec4f(intensity, intensity, intensity, 1.0);
+
+    textureStore(texture, vec2(i32(id.x), i32(id.y)), vec4(intensity, intensity, intensity, 1.0));
 }
 
 fn complex_square(z: vec2f) -> vec2f {


### PR DESCRIPTION
Now the GPU will render onto the same softbuffer surface as the CPU would.
This was necessary otherwise, for some not yet understood reasons, we could not switch between GPU and CPU based rendering after the GPU made a single render.

In terms of this exercise it is probably better that we were forced to make this change, because the GPU now can be written as a compute shader and become a bit cleaner as well.